### PR TITLE
Fix built-in `name`, fix java8 error

### DIFF
--- a/src/main/java/me/exz/omniocular/network/NetworkHelper.java
+++ b/src/main/java/me/exz/omniocular/network/NetworkHelper.java
@@ -27,7 +27,7 @@ public class NetworkHelper {
                 ConfigHandler.mergedConfig = "";
                 break;
             case "__END__":
-                LogHelper.info("received config: " + ConfigHandler.mergedConfig);
+//                LogHelper.info("received config: " + ConfigHandler.mergedConfig);
                 ConfigHandler.parseConfigFiles();
                 break;
             default:


### PR DESCRIPTION
- select js engine by java version, fix #70 
- type of `hashCode` in the built-in function `name` should be number, fix #71 

另外还删除了进入存档时的巨量log.

不过我对 gradle 的构建知之甚少，本地测试用的是 GTNH 的 [gradle 模板](https://github.com/GTNewHorizons/ExampleMod1.7.10)。通过 gradle 启动可以正常运行，但是构建生成的 jar 加入到 GTNH 整合包后无法找到 graal js 引擎。